### PR TITLE
Replace session store with cookie store when storing Queue-IT queue number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 3.0.0 - 2021-07-30
+
+* Replace session store with cookie store to prevent some users of being kicked out of the queue
+
 ### 2.0.2 - 2021-07-21
 
 * Defaults changed when creating/updating a queue: CustomLayout set to dark theme, MaxNoOfRedirectsPrQueueId to 3, QueueNumberValidityInMinutes to 30.

--- a/lib/queue_it/version.rb
+++ b/lib/queue_it/version.rb
@@ -1,3 +1,3 @@
 module QueueIt
-  VERSION = "2.0.2"
+  VERSION = "3.0.0"
 end


### PR DESCRIPTION
This should prevent kicking out some users of of the queue when the app session is reset